### PR TITLE
fix: default to nodePort

### DIFF
--- a/internal/bundle/application/applications/ambassador/helm/default.go
+++ b/internal/bundle/application/applications/ambassador/helm/default.go
@@ -73,19 +73,19 @@ func DefaultValues(imageTags map[string]string) *Values {
 			RunAsUser: 8888,
 		},
 		Service: &Service{
-            Type: "NodePort",
+			Type: "NodePort",
 			Ports: []*Port{
 				&Port{
 					Name:       "http",
 					Port:       80,
-                    TargetPort: 8080,
-                    NodePort: 30080,
+					TargetPort: 8080,
+					NodePort:   30080,
 				},
 				&Port{
 					Name:       "https",
 					Port:       443,
-                    TargetPort: 8443,
-                    NodePort: 30443,
+					TargetPort: 8443,
+					NodePort:   30443,
 				},
 			},
 		},

--- a/internal/bundle/application/applications/ambassador/helm/default.go
+++ b/internal/bundle/application/applications/ambassador/helm/default.go
@@ -73,16 +73,19 @@ func DefaultValues(imageTags map[string]string) *Values {
 			RunAsUser: 8888,
 		},
 		Service: &Service{
+            Type: "NodePort",
 			Ports: []*Port{
 				&Port{
 					Name:       "http",
 					Port:       80,
-					TargetPort: 8080,
+                    TargetPort: 8080,
+                    NodePort: 30080,
 				},
 				&Port{
 					Name:       "https",
 					Port:       443,
-					TargetPort: 8443,
+                    TargetPort: 8443,
+                    NodePort: 30443,
 				},
 			},
 		},

--- a/internal/bundle/application/applications/ambassador/helm/values.go
+++ b/internal/bundle/application/applications/ambassador/helm/values.go
@@ -82,8 +82,9 @@ type SecurityContext struct {
 }
 type Port struct {
 	Name       string `yaml:"name"`
-	Port       int    `yaml:"port"`
-	TargetPort int    `yaml:"targetPort"`
+	Port       uint16 `yaml:"port"`
+	TargetPort uint16 `yaml:"targetPort"`
+	NodePort   uint16 `yaml:"nodePort"`
 }
 type Service struct {
 	Annotations interface{} `yaml:"annotations"`


### PR DESCRIPTION
We should default to `nodePort` instead of `ClusterIP`, otherwise we will not server any traffic.