### PR TITLE
fix: ignore missing etcd, systemd and orbiter probes on gke

### DIFF
--- a/internal/bundle/application/applications/prometheus/helm/rules.go
+++ b/internal/bundle/application/applications/prometheus/helm/rules.go
@@ -158,7 +158,7 @@ groups:
          1
        )          
      record: caos_scheduled_pods_ryg
-   - expr: min(caos_node_cpu_ryg) * min(caos_systemd_ryg) * min(caos_vip_probe_ryg) * min(caos_upstream_probe_ryg) * min(caos_node_memory_ryg) * min(caos_k8s_node_ryg) * avg(caos_etcd_ryg) * min(caos_ready_pods_ryg{namespace=~"(caos|kube)-system"}) * min(caos_scheduled_pods_ryg{namespace=~"(caos|kube)-system"})
+   - expr: min(caos_node_cpu_ryg) * min(caos_systemd_ryg or on() vector(1)) * min(caos_vip_probe_ryg or on() vector(1)) * min(caos_upstream_probe_ryg or on() vector(1)) * min(caos_node_memory_ryg) * min(caos_k8s_node_ryg) * min(caos_etcd_ryg or on() vector(1)) * min(caos_ready_pods_ryg{namespace=~"(caos|kube)-system"}) * min(caos_scheduled_pods_ryg{namespace=~"(caos|kube)-system"})
      record: caos_orb_ryg
 `
 


### PR DESCRIPTION
Dashboards are untouched, but missing etcd, systemd and orbiter probe
metrics don't cause the overall cluster healthyness to turn red

✅ Closes: #86